### PR TITLE
Fix getting email from github json response

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -19,7 +19,7 @@ function authIdCallback(accessToken, refreshToken, profile, callback) {
     var userData = {
         authId: profile.id + "@" + profile.provider,
         name: profile.displayName ? profile.displayName : profile.username,
-        email: profile.emails ? profile.emails.length ? profile.emails[0] : null : null
+        email: profile.emails ? profile.emails.length ? profile.emails[0].value : null : null
     };
 
     User.findOrCreate(userData, function (err, user) {


### PR DESCRIPTION
When 'emails' exists in the json response, it looks like:

emails: [ { value: 'your.email@mail.com' } ],

So a json was sent to be deserialized instead of a string, which threw
an error:

"Could not read document: Can not deserialize instance of
java.lang.String out of START_OBJECT token"
